### PR TITLE
add option to save learning plan as .txt file

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -3,6 +3,8 @@ from typing import TypedDict
 from nodes.ask_user_input import ask_user_input_node
 from nodes.classify_profile import classify_profile_node
 from nodes.generate_plan import generate_plan_node
+import datetime
+import re
 
 # Updated state schema
 class LearningState(TypedDict):
@@ -32,3 +34,18 @@ if __name__ == "__main__":
     print(result["user_profile"])
     print("\n📘 Personalized learning plan:")
     print(result["learning_plan"])
+
+    # offer to save
+    save = input("\n Do you want to save this learning plan as a .txt file? (y/n): ").strip().lower()
+    if save == "y":
+        goal = result["goal"]
+        goal_snippet = re.sub(r'\W+', '_', goal.strip())[:20]
+        today = datetime.date.today().isoformat()
+        filename = f"{goal_snippet}_{today}.txt"
+
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write(f"User Profile: {result['user_profile']}\n\n")
+            f.write("Personalized Learning Plan:\n")
+            f.write(result["learning_plan"])
+
+        print(f"Learning plan saved as '{filename}'")


### PR DESCRIPTION
### Summary
Adds an optional feature that allows the user to save their generated learning plan as a plain `.txt` file.

### Details
- Asks the user after generating the plan if they want to save it.
- If yes, the plan is saved in the same directory.
- The filename includes a short version of the user's goal and the current date.

### Example filename
learn_python_2025-07-23.txt

Closes #4
